### PR TITLE
IP-2721: boilerplate에 패키지 version 고정

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:dev": "vite build --mode=development",
     "preview": "vite preview",
     "test": "jest --watchAll --silent",
-    "presetup": "yarn add -D shelljs del compare-versions chalk",
+    "presetup": "yarn add -D shelljs del@6.1.1 compare-versions chalk@4.1.2",
     "setup": "node ./scripts/setup.js",
     "postsetup": "yarn remove shelljs del compare-versions chalk"
   },

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -153,7 +153,7 @@ function checkNodeVersion(minimalNodeVersion) {
       const nodeVersion = stdout.trim();
       if (err) {
         reject(new Error(err));
-      } else if (compareVersions(nodeVersion, minimalNodeVersion) === -1) {
+      } else if (compareVersions.compareVersions(nodeVersion, minimalNodeVersion) === -1) {
         reject(
           new Error(
             `You need Node.js v${minimalNodeVersion} or above but you have v${nodeVersion}`
@@ -177,7 +177,7 @@ function checkYarnVersion(minimalYarnVersion) {
       const yarnVersion = stdout.trim();
       if (err) {
         reject(new Error(err));
-      } else if (compareVersions(yarnVersion, minimalYarnVersion) === -1) {
+      } else if (compareVersions.compareVersions(yarnVersion, minimalYarnVersion) === -1) {
         reject(
           new Error(
             `You need Yarn v${minimalYarnVersion} or above but you have v${yarnVersion}`


### PR DESCRIPTION
## 목적
- presetup 에서 chalk와 del 패키지의 버전을 고정합니다 (require 를 제외한 버전으로 메이저 버전이 변경되어 setup 내용을 사용할 수 없어 변경)
- compareVersions 패키지에서 import 후, compareVersions 함수를 호출하도록 변경합니다.

## 변경 사항
- presetup 변경 `yarn add -D shelljs del@6.1.1 compare-versions chalk@4.1.2`
- compareVersions.compareVersions로 함수 변경

## TODO
-

## Followers